### PR TITLE
Feature/specs PowerShellModule

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,12 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Publisher.ps1 from current folder",
+      "type": "PowerShell",
+      "request": "launch",
+      "script": "${cwd}/src/publisher.ps1"
+    },
+    {
       "name": "Publisher.ps1",
       "type": "PowerShell",
       "request": "launch",

--- a/src/specs.include.ps1
+++ b/src/specs.include.ps1
@@ -493,6 +493,7 @@ function ConvertTo-PowerShellModuleFunctionHelp {
       New-Item $Target -ItemType Directory | Out-Null
     }
 
+    Write-Debug "[PlatyPs] New-MarkdownHelp -Command $name"
     $generated = New-MarkdownHelp -Command $name -OutputFolder $Target -Verbose -Force
 
     if ([string]::IsNullOrEmpty($ModuleRelativePath)) {
@@ -521,6 +522,12 @@ function ConvertTo-PowerShellModuleFunctionHelp {
 function Get-PowerShellModuleViewModel {
   param($moduleDetails, $ModuleRelativePath, $CloneUrl, $RepoBranch = "main")
 
+  Write-Debug "Get-PowerShellModuleViewModel"
+  Write-Debug "moduleDetails      = [$($moduleDetails)]"
+  Write-Debug "ModuleRelativePath = [$($ModuleRelativePath)]"
+  Write-Debug "CloneUrl           = [$($CloneUrl)]"
+  Write-Debug "RepoBranch         = [$($RepoBranch)]"
+
   $href = Get-PowerShellModuleItemUri -CloneUrl $CloneUrl -ModuleRelativePath $ModuleRelativePath -ItemRelativePath $moduleDetails.RootModule
 
   $ret = [ordered]@{
@@ -539,7 +546,7 @@ function Get-PowerShellModuleViewModel {
     Branch             = $RepoBranch
     Path               = "$href".Split("?path=")[1]
     RootModuleUri      = "$href"
-    ExportedFunctions  = $moduleDetails.ExportedFunctions.Values | sort-object | get-help | select-object name, Synopsis
+    ExportedFunctions  = Get-Command -module $moduleDetails.Name | sort-object Name | get-help | select-object name, Synopsis
     Raw                = $moduleDetails
   }
 
@@ -686,7 +693,7 @@ function Convert-DocResource {
       $moduleDetails = Get-Module $spec.Name
       $exportedFunctions = Get-PowerShellModuleExportedFunction -ModuleDetails $moduleDetails
       $exportedFunctions | ConvertTo-PowerShellModuleFunctionHelp -CloneUrl $spec.CloneUrl -ModuleRelativePath $spec.RepoRelativePath -RepoBranch $spec.Branch -Target $Destination
-      $viewModel = Get-PowerShellModuleViewModel -moduleDetails $moduleDetails -CloneUrl $spec.CloneUrl $spec.RepoRelativePath -RepoBranch $spec.Branch
+      $viewModel = Get-PowerShellModuleViewModel -moduleDetails $moduleDetails -CloneUrl $spec.CloneUrl -ModuleRelativePath $spec.RepoRelativePath -RepoBranch $spec.Branch
       New-PowerShellModuleIndex -ViewModel $viewModel -Target $Destination
       New-PowerShellModuleToc -ViewModel $viewModel -Target $Destination
             

--- a/src/specs.ps1
+++ b/src/specs.ps1
@@ -32,6 +32,8 @@ param(
     $VerbosePreference = 'Continue'
 #>
 
+$env:DocFxHelper_Publisher = $true
+
 . $PSScriptRoot/specs.include.ps1
 
 $script:SpecsVersions = @(


### PR DESCRIPTION
- Fix: Failing Import-Module of modules where psm1 script contains calls to initializing 
 
Introduction of a new environment variable $env:DocFxHelper_Publisher = $true.  

The owner of the module can now leverage the $env:DocFxHelper_Publisher variable and skip this initializing steps.

- Fix: stalled Get-Help when generating PowerShellModule index.md
